### PR TITLE
Nftadroid 80

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -59,7 +59,7 @@
         <entry key="app/src/main/res/layout/fragment_gift_nft.xml" value="0.12552083333333333" />
         <entry key="app/src/main/res/layout/fragment_history.xml" value="0.4306256306760848" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.3242320819112628" />
-        <entry key="app/src/main/res/layout/fragment_login.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_login.xml" value="0.14106742651468587" />
         <entry key="app/src/main/res/layout/fragment_main.xml" value="0.21822916666666667" />
         <entry key="app/src/main/res/layout/fragment_nft_minted.xml" value="0.4233576642335766" />
         <entry key="app/src/main/res/layout/fragment_otp.xml" value="0.2345389554446723" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,7 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="../../../../layout/custom_preview.xml" value="0.578125" />
+        <entry key="../../../layout/custom_preview.xml" value="0.25677083333333334" />
         <entry key="..\:/testprojects/naps_nft/app/src/main/res/layout/activity_main.xml" value="0.23777173913043478" />
         <entry key="..\:/testprojects/naps_nft/app/src/main/res/layout/dialog_create_nft.xml" value="0.23777173913043478" />
         <entry key="..\:/testprojects/naps_nft/app/src/main/res/layout/dialog_send_consent_ntf.xml" value="0.23777173913043478" />
@@ -51,14 +52,14 @@
         <entry key="app/src/main/res/layout/dialog_send_nft_result.xml" value="0.1" />
         <entry key="app/src/main/res/layout/dialog_send_select_people_ntf.xml" value="0.1" />
         <entry key="app/src/main/res/layout/dialog_successful_nft.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/fragment_claim_nft.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_claim_nft.xml" value="0.22713845144638797" />
         <entry key="app/src/main/res/layout/fragment_consent.xml" value="0.2914285714285714" />
         <entry key="app/src/main/res/layout/fragment_create_nft.xml" value="0.22" />
         <entry key="app/src/main/res/layout/fragment_create_nft_preview.xml" value="0.125" />
         <entry key="app/src/main/res/layout/fragment_gift_nft.xml" value="0.12552083333333333" />
         <entry key="app/src/main/res/layout/fragment_history.xml" value="0.4306256306760848" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.3242320819112628" />
-        <entry key="app/src/main/res/layout/fragment_login.xml" value="0.31238095238095237" />
+        <entry key="app/src/main/res/layout/fragment_login.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_main.xml" value="0.21822916666666667" />
         <entry key="app/src/main/res/layout/fragment_nft_minted.xml" value="0.4233576642335766" />
         <entry key="app/src/main/res/layout/fragment_otp.xml" value="0.2345389554446723" />
@@ -66,7 +67,7 @@
         <entry key="app/src/main/res/layout/fragment_send_nft.xml" value="0.25" />
         <entry key="app/src/main/res/layout/fragment_sent_history.xml" value="0.8890625" />
         <entry key="app/src/main/res/layout/fragment_setting.xml" value="0.25" />
-        <entry key="app/src/main/res/layout/fragment_signup.xml" value="0.125" />
+        <entry key="app/src/main/res/layout/fragment_signup.xml" value="0.18487397019721913" />
         <entry key="app/src/main/res/layout/fragment_transaction.xml" value="0.4306256306760848" />
         <entry key="app/src/main/res/layout/inc_nft_preview.xml" value="0.4306256306760848" />
         <entry key="app/src/main/res/layout/inc_nft_upload.xml" value="0.33" />

--- a/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/LoginApi.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/LoginApi.kt
@@ -5,6 +5,7 @@ import com.nearlabs.nftmarketplace.data.networks.request.DtoLoginRequest
 import com.nearlabs.nftmarketplace.data.networks.request.DtoUserCreateRequest
 import com.nearlabs.nftmarketplace.data.networks.response.DtoLoginResponse
 import com.nearlabs.nftmarketplace.data.networks.response.DtoUserInfoResponse
+import com.nearlabs.nftmarketplace.data.networks.response.DtoVerifyLoginResponse
 import retrofit2.http.*
 
 interface LoginApi {
@@ -12,5 +13,5 @@ interface LoginApi {
     suspend fun login(@Body walletName : DtoLoginRequest): DtoLoginResponse
 
     @POST("login/verify")
-    suspend fun verifyLogin(@Body walletName : DtoLoginRequest): DtoLoginResponse
+    suspend fun verifyLogin(@Body walletName : DtoLoginRequest): DtoVerifyLoginResponse
 }

--- a/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/response/DtoContact.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/response/DtoContact.kt
@@ -15,7 +15,7 @@ data class DtoContact(
 	@SerializedName("created")
 	val created: String? = null,
 
-	@SerializedName("lastName")
+	@SerializedName("last_Name")
 	val lastName: String? = null,
 
 	@SerializedName("groups")
@@ -39,7 +39,7 @@ data class DtoContact(
 	@SerializedName("import_source")
 	val importSource: String? = null,
 
-	@SerializedName("firstName")
+	@SerializedName("first_Name")
 	val firstName: String? = null,
 
 	@SerializedName("job_title")

--- a/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/response/DtoVerifyLoginResponse.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/response/DtoVerifyLoginResponse.kt
@@ -1,4 +1,15 @@
 package com.nearlabs.nftmarketplace.data.networks.response
 
-class DtoVerifyLoginResponse {
-}
+import com.google.gson.annotations.SerializedName
+
+data class DtoVerifyLoginResponse (
+
+    @SerializedName("user_info")
+    val userInfo: DtoUserResponse,
+    @SerializedName("jwt_access_token")
+    val accessToken: String,
+    @SerializedName("jwt_id_token")
+    val idToken: String,
+    @SerializedName("jwt_refresh_token")
+    val refreshToken: String,
+)

--- a/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/response/DtoVerifyLoginResponse.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/data/networks/response/DtoVerifyLoginResponse.kt
@@ -1,0 +1,4 @@
+package com.nearlabs.nftmarketplace.data.networks.response
+
+class DtoVerifyLoginResponse {
+}

--- a/app/src/main/java/com/nearlabs/nftmarketplace/repository/Repository.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/repository/Repository.kt
@@ -128,9 +128,13 @@ class Repository(
                 nonce = nonce
             )
             val dtoResponse = loginApi.verifyLogin(request).apply {
-
+                sharePrefs.userId = userInfo.id
+                sharePrefs.userName = userInfo.fullName ?: ""
+                sharePrefs.accessToken = accessToken
+                sharePrefs.idToken = idToken
+                sharePrefs.refreshToken = refreshToken
+                sharePrefs.userInfo = Gson().toJson(userInfo)
             }
-
         }
 
 

--- a/app/src/main/java/com/nearlabs/nftmarketplace/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/ui/auth/LoginFragment.kt
@@ -1,7 +1,9 @@
 package com.nearlabs.nftmarketplace.ui.auth
 
 import android.content.res.ColorStateList
+import android.graphics.Color
 import android.os.Bundle
+import android.text.InputType
 import android.view.View
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -26,7 +28,6 @@ class LoginFragment : BaseFragment(R.layout.fragment_login) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         initListeners()
     }
 
@@ -57,13 +58,19 @@ class LoginFragment : BaseFragment(R.layout.fragment_login) {
 
         binding.tvPhoneLogin.setOnClickListener {
             AppConstants.logAppsFlyerEvent(CLICK_LOGIN_WITH_PHONE_EVENT_NAME,it.context)
+            binding.tvPhoneLogin.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.light_grey))
+            binding.tvEmailLogin.backgroundTintList = ColorStateList.valueOf(Color.WHITE)
             binding.etEmailPhone.hint = requireActivity().getString(R.string.phone_example)
+            binding.etEmailPhone.inputType = InputType.TYPE_CLASS_PHONE
             userViewModel.usesPhone = true
         }
 
         binding.tvEmailLogin.setOnClickListener {
             AppConstants.logAppsFlyerEvent(CLICK_LOGIN_WITH_PHONE_EVENT_NAME,it.context)
+            binding.tvPhoneLogin.backgroundTintList = ColorStateList.valueOf(Color.WHITE)
+            binding.tvEmailLogin.backgroundTintList = ColorStateList.valueOf(resources.getColor(R.color.light_grey))
             binding.etEmailPhone.hint = requireActivity().getString(R.string.email_example)
+            binding.etEmailPhone.inputType = InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
             userViewModel.usesPhone = false
 
         }

--- a/app/src/main/java/com/nearlabs/nftmarketplace/ui/auth/OTPFragment.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/ui/auth/OTPFragment.kt
@@ -1,9 +1,12 @@
 package com.nearlabs.nftmarketplace.ui.auth
 
+import android.content.res.ColorStateList
 import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.nearlabs.nftmarketplace.R
@@ -38,6 +41,30 @@ class OTPFragment: BaseFragment(R.layout.fragment_otp) {
     }
 
     private fun initListeners() {
+        binding.edt1.doAfterTextChanged {
+            binding.edt2.requestFocus()
+        }
+        binding.edt2.doAfterTextChanged {
+            binding.edt3.requestFocus()
+        }
+        binding.edt3.doAfterTextChanged {
+            binding.edt4.requestFocus()
+        }
+        binding.edt4.doAfterTextChanged {
+            binding.edt5.requestFocus()
+        }
+        binding.edt5.doAfterTextChanged {
+            binding.edt6.requestFocus()
+        }
+        binding.edt6.doAfterTextChanged {
+            binding.edt6.clearFocus()
+            binding.btnContinue.backgroundTintList = ColorStateList.valueOf(
+                ContextCompat.getColor(
+                    requireContext(),
+                    if (it.isNullOrBlank()) R.color.btndisabled_color else R.color.blue
+                )
+            )
+        }
         binding.btnContinue.setOnClickListener {
             AppConstants.logAppsFlyerEvent(OTP_VERIFICATION_EVENT_NAME,it.context)
             val nonce = StringBuilder()

--- a/app/src/main/java/com/nearlabs/nftmarketplace/ui/auth/SignupFragment.kt
+++ b/app/src/main/java/com/nearlabs/nftmarketplace/ui/auth/SignupFragment.kt
@@ -68,7 +68,7 @@ class SignupFragment : BaseFragment(R.layout.fragment_signup) {
         binding.btnCreateAccount.backgroundTintList = ColorStateList.valueOf(
             ContextCompat.getColor(
                 requireContext(),
-                if (binding.fullName.text.isNullOrBlank() || binding.walletId.text.isNullOrBlank()) R.color.btndisabled_color else R.color.blue
+                if (binding.fullName.text.isNullOrBlank() || binding.walletId.text.isNullOrBlank()) R.color.btndisabled_color else R.color.black
             )
         )
     }

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -50,33 +50,31 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="15dp"
                 android:backgroundTint="@color/white"
+                android:elevation="0dp"
                 android:fontFamily="@font/inter_medium"
                 android:gravity="center"
                 android:paddingHorizontal="10dp"
                 android:paddingVertical="5dp"
                 android:text="@string/email"
-                android:textColor="@color/text_selected"
-                android:textSize="18sp"
                 android:textAllCaps="false"
-                android:elevation="0dp"
-                />
+                android:textColor="@color/text_selected"
+                android:textSize="18sp" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/tvPhoneLogin"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:backgroundTint="@color/white"
+                android:backgroundTint="@color/light_grey"
+                android:elevation="0dp"
+                android:focusedByDefault="true"
                 android:fontFamily="@font/inter_medium"
                 android:gravity="center"
                 android:paddingHorizontal="10dp"
                 android:paddingVertical="5dp"
                 android:text="@string/phone"
-                android:textColor="@color/text_selected"
-                android:textSize="18sp"
                 android:textAllCaps="false"
-                android:focusedByDefault="true"
-                android:elevation="0dp"
-                />
+                android:textColor="@color/text_selected"
+                android:textSize="18sp" />
 
 
         </androidx.appcompat.widget.LinearLayoutCompat>
@@ -90,10 +88,12 @@
             android:layout_marginEnd="14dp"
             android:background="@drawable/input_field_bg"
             android:fontFamily="@font/inter_regular"
+            android:inputType="phone"
             android:hint="@string/phone_example"
             android:paddingHorizontal="14dp"
             android:textColor="@color/black"
             android:textColorHint="@color/hint_color"
+            android:maxLines="1"
             android:layout_gravity="center_horizontal"/>
 
         <com.google.android.material.button.MaterialButton
@@ -102,7 +102,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="14dp"
             android:backgroundTint="@color/btndisabled_color"
-            android:paddingHorizontal="25dp"
+            android:paddingHorizontal="15dp"
             android:drawableEnd="@drawable/ic_arrow_forward"
             android:fontFamily="@font/inter_medium"
             android:gravity="center"
@@ -146,7 +146,9 @@
             android:paddingHorizontal="14dp"
             android:textColor="@color/black"
             android:textColorHint="@color/hint_color"
-            android:layout_gravity="center_horizontal"/>
+            android:maxLines="1"
+            android:layout_gravity="center_horizontal"
+            android:inputType="text"/>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnLogin"
@@ -154,7 +156,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:backgroundTint="@color/blue"
-            android:paddingHorizontal="25dp"
+            android:paddingHorizontal="15dp"
             android:drawableEnd="@drawable/ic_arrow_forward"
             android:fontFamily="@font/inter_medium"
             android:gravity="center"

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -42,7 +42,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:gravity="center"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:layoutDirection="ltr">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/tvEmailLogin"

--- a/app/src/main/res/layout/fragment_otp.xml
+++ b/app/src/main/res/layout/fragment_otp.xml
@@ -35,6 +35,17 @@
                     android:textColor="@color/black"
                     android:textSize="21sp" />
 
+                <ProgressBar
+                    style="?android:attr/progressBarStyleHorizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentBottom="true"
+                    android:layout_marginTop="50dp"
+                    android:maxHeight="2dp"
+                    android:minHeight="2dp"
+                    android:progress="33"
+                    android:progressTint="@color/blue" />
+
                 <RelativeLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -113,6 +124,8 @@
                     android:gravity="center"
                     android:nextFocusForward="@id/edt2"
                     android:maxLines="1"
+                    android:maxLength="1"
+                    android:inputType="number"
                     />
                 <androidx.appcompat.widget.AppCompatEditText
                     android:layout_width="0dp"
@@ -125,6 +138,8 @@
                     android:gravity="center"
                     android:nextFocusForward="@id/edt3"
                     android:maxLines="1"
+                    android:maxLength="1"
+                    android:inputType="number"
                     />
                 <androidx.appcompat.widget.AppCompatEditText
                     android:layout_width="0dp"
@@ -137,6 +152,8 @@
                     android:gravity="center"
                     android:nextFocusForward="@id/edt4"
                     android:maxLines="1"
+                    android:maxLength="1"
+                    android:inputType="number"
                     />
                 <androidx.appcompat.widget.AppCompatEditText
                     android:layout_width="0dp"
@@ -149,6 +166,8 @@
                     android:gravity="center"
                     android:nextFocusForward="@id/edt5"
                     android:maxLines="1"
+                    android:maxLength="1"
+                    android:inputType="number"
                     />
                 <androidx.appcompat.widget.AppCompatEditText
                     android:layout_width="0dp"
@@ -161,6 +180,8 @@
                     android:gravity="center"
                     android:nextFocusForward="@id/edt6"
                     android:maxLines="1"
+                    android:maxLength="1"
+                    android:inputType="number"
                     />
                 <androidx.appcompat.widget.AppCompatEditText
                     android:layout_width="0dp"
@@ -171,6 +192,8 @@
                     android:gravity="center"
                     android:cursorVisible="false"
                     android:maxLines="1"
+                    android:maxLength="1"
+                    android:inputType="number"
                     />
 
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -33,6 +33,17 @@
                     android:textColor="@color/black"
                     android:textSize="21sp" />
 
+                <ProgressBar
+                    style="?android:attr/progressBarStyleHorizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentBottom="true"
+                    android:layout_marginTop="50dp"
+                    android:maxHeight="2dp"
+                    android:minHeight="2dp"
+                    android:progress="66"
+                    android:progressTint="@color/blue" />
+
                 <RelativeLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -121,13 +132,14 @@
                 android:layout_marginTop="33dp"
                 android:backgroundTint="@color/btndisabled_color"
                 android:gravity="center"
-                android:paddingHorizontal="26dp"
+                android:paddingHorizontal="15dp"
                 android:drawableEnd="@drawable/ic_arrow_forward"
                 android:fontFamily="@font/inter_medium"
                 android:text="@string/create_an_account"
                 android:textColor="@color/white"
                 android:textSize="17sp"
                 android:textAllCaps="false"
+                app:cornerRadius="7dp"
                 android:layout_gravity="center_horizontal"/>
 
             <androidx.appcompat.widget.AppCompatTextView
@@ -164,15 +176,17 @@
                 android:layout_marginHorizontal="36dp"
                 android:layout_marginTop="16dp"
                 android:backgroundTint="@color/blue"
-                android:paddingHorizontal="24dp"
+                android:paddingHorizontal="15dp"
                 android:drawableEnd="@drawable/ic_arrow_forward"
                 android:fontFamily="@font/inter_medium"
                 android:gravity="center"
                 android:text="@string/login_with_NEAR"
                 android:textColor="@color/white"
-                android:textSize="18sp"
+                android:textSize="16sp"
                 android:layout_gravity="center_horizontal"
-                android:textAllCaps="false"/>
+                android:textAllCaps="false"
+                app:cornerRadius="7dp"
+                />
 
         </LinearLayout>
 


### PR DESCRIPTION
On Login Screen:

Fixed issue where RTL languages would swap the buttons around (email and phone)

Email/phone signup textfield and wallet name text field is now limited to 1 line.

Change colors of buttons (email and phone) when one or the other is selected (and set phone to light gray as it is default selected)

Set initial input type to phone (since it starts on phone)

The phone input should have phone input type (only numbers on keyboard)

Email input should only have email input on keyboard

Create Account screen:

colors changed and added progress bar up top (like design)

Verification Screen:

Verification boxes now automatically go to next one after typing 1 digit (and they’re now single line input and limited to 1 character)

Continue button now changes to blue when all 6 are filled

Add progress bar to top (like in design)